### PR TITLE
add buildtool_depend for catkin-pkg-modules

### DIFF
--- a/cv_bridge_python3/package.xml
+++ b/cv_bridge_python3/package.xml
@@ -24,6 +24,7 @@
   </export>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python3-catkin-pkg-modules</buildtool_depend>
 
   <build_depend>boost</build_depend>
   <build_depend>libopencv-dev</build_depend>


### PR DESCRIPTION
I cannot open issue on this fork, so I make this PR.
`ros-melodic-cv-bridge-python3` build failed on `build.ros.org`.
https://build.ros.org/job/Mbin_uB64__cv_bridge_python3__ubuntu_bionic_amd64__binary/
http://packages.ros.org/ros-testing/ubuntu/pool/main/r/ros-melodic-cv-bridge-python3/

This PR add dependency on `catkin_pkg` for python3.

```
15:20:07 -- Using Python nosetests: /usr/bin/nosetests
15:20:07 ImportError: "from catkin_pkg.package import parse_package" failed: No module named 'catkin_pkg'
15:20:07 Make sure that you have installed "catkin_pkg", it is up to date and on the PYTHONPATH.
15:20:07 CMake Error at /opt/ros/melodic/share/catkin/cmake/safe_execute_process.cmake:11 (message):
15:20:07   execute_process(/usr/bin/python3
15:20:07   "/opt/ros/melodic/share/catkin/cmake/parse_package_xml.py"
15:20:07   "/opt/ros/melodic/share/catkin/cmake/../package.xml"
15:20:07   "/tmp/binarydeb/ros-melodic-cv-bridge-python3-1.13.1/obj-x86_64-linux-gnu/catkin/catkin_generated/version/package.cmake")
15:20:07   returned error code 1
15:20:07 Call Stack (most recent call first):
15:20:07   /opt/ros/melodic/share/catkin/cmake/catkin_package_xml.cmake:74 (safe_execute_process)
15:20:07   /opt/ros/melodic/share/catkin/cmake/all.cmake:168 (_catkin_package_xml)
15:20:07   /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:20 (include)
15:20:07   CMakeLists.txt:8 (find_package)
15:20:07 
15:20:07 
15:20:07 -- Configuring incomplete, errors occurred!
```